### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A label that switches texts by animating a flip of each letter - Written in Swif
 ## Requirements
 
 * iOS 8.0+
-* xCode 6+
+* Xcode 6+
 
 ## Example App 
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
